### PR TITLE
Clarify racing behavior for A/AAAA and SVCB parallel queries. Give rationale to A/AAAA answer preference.

### DIFF
--- a/draft-nygren-dnsop-svcb-httpssvc.md
+++ b/draft-nygren-dnsop-svcb-httpssvc.md
@@ -302,7 +302,7 @@ The presentation format of the record is:
 
     Name TTL IN SVCB SvcFieldPriority SvcDomainName SvcFieldValue
 
-The SVCB record is defined specifically within 
+The SVCB record is defined specifically within
 the Internet ("IN") Class ({{!RFC1035}}).
 SvcFieldPriority is a number in the range 0-65535,
 SvcDomainName is a domain name,
@@ -542,7 +542,7 @@ following procedure:
    SvcDomainName if they are not already available.  These are the
    preferred SvcFieldValue and IP addresses.  If the connection fails, the
    client MAY try to connect using values from a lower-priority record.
-   If none of the options succeed, the client SHOULD connect to the origin 
+   If none of the options succeed, the client SHOULD connect to the origin
    server directly.
 
 4. If an SVCB record for HOST does not exist, the received AAAA and/or A
@@ -551,7 +551,7 @@ following procedure:
 This procedure does not rely on any recursive or authoritative server to
 comply with this specification or have any awareness of SVCB.
 
-When selecting between AAAA and A records to use, clients may use an approach 
+When selecting between AAAA and A records to use, clients may use an approach
 such as {{!HappyEyeballsV2=RFC8305}}.
 
 Some important optimizations are discussed in {{optimizations}}
@@ -627,18 +627,19 @@ in cache before performing any followup queries.
 With these optimizations in place, and conforming DNS servers,
 using SVCB does not add network latency to connection setup.
 
-Moreover, if an A or AAAA response arrives before an SVCB response, a client which 
-prefers ESNI SHOULD wait up to CD milliseconds before starting secure connections 
-to either address. (Clients may begin TCP connections in this time. QUIC connections 
-should wait. This allows receipt of latent keying material in a SVCR repsonse.) 
-If an SVCB record with a "esnikeys" value and "ipv4hint" or "ipv6hint" values 
-arrives and one of those hints matches an in-progress connection, the secure 
-connection should proceed using the provided ESNI keying material. However, if 
-neither a "ipv4hint" nor "ipv6hint" is available, the client MUST resolve the 
-SvcDomainName in the SVCB response and connect to the preferred A or AAAA adddress
-according to the procedure in {{client-behavior}}.
+Moreover, if an A or AAAA response arrives before an SVCB response, a client which
+prefers ESNI SHOULD wait up to CD milliseconds before starting secure connections
+to either address. (Clients may begin TCP connections in this time. QUIC connections
+should wait. This allows receipt of latent keying material in a SVCB repsonse.)
+If an SVCB record with a "esnikeys" value and "ipv4hint" or "ipv6hint" values
+arrives and one of those hints matches an in-progress connection, the secure
+connection should proceed using the provided ESNI keying material. If neither a
+"ipv4hint" nor "ipv6hint" is available, clients must then resolve the SvcDomainName
+in the SVCB response to the preferred A or AAAA adddress. If a client's DNS cache has
+valid A or AAAA records for the SvcDomainName, those SHOULD be used. Otherwise,
+clients MUST resolve SvcDomainName to according to the procedure in {{client-behavior}}.
 
-CD (Connection Delay) is a configurable parameter.  The recommended value is 50 
+CD (Connection Delay) is a configurable parameter.  The recommended value is 50
 milliseconds, as per the guidance in {{!HappyEyeballsV2=RFC8305}}.
 
 A nonconforming recursive resolver might not return all the information

--- a/draft-nygren-dnsop-svcb-httpssvc.md
+++ b/draft-nygren-dnsop-svcb-httpssvc.md
@@ -628,7 +628,7 @@ With these optimizations in place, and conforming DNS servers,
 using SVCB does not add network latency to connection setup.
 
 Moreover, if an A or AAAA response arrives before an SVCB response, the
-client SHOULD wait up to CD milliseconds before connecting as if the
+client MAY wait up to CD milliseconds before connecting as if the
 SVCB query returned NODATA, but MUST NOT transmit any information that
 could be altered by an SVCB response until the SVCB response arrives.
 For example, a TLS ClientHello may be altered by the "esnikeys" value
@@ -637,8 +637,13 @@ is a configurable parameter. The recommended value is 50 milliseconds,
 as per the guidance in {{!HappyEyeballsV2=RFC8305}}.
 
 An SVCB record is consistent with an active or in-progress connection C
-if the A or AAAA address for its SvcDomainName matches the destination
-address of C. If an SVCB record is consistent with an active or in-progress
+if the following conditions are met:
+
+1. The A or AAAA address for its SvcDomainName matches the destination
+address of C.
+2. The destination port of C matches that specified in the SVCB record.
+
+If an SVCB record is consistent with an active or in-progress
 connection C, the client may continue using C with any information provided
 by the SVCB record. For example, if an SVCB record with a "esnikeys" value and
 "ipv4hint" or "ipv6hint" values {{svcparamkeys-iphints}} arrives, and one of

--- a/draft-nygren-dnsop-svcb-httpssvc.md
+++ b/draft-nygren-dnsop-svcb-httpssvc.md
@@ -631,28 +631,30 @@ Moreover, if an A or AAAA response arrives before an SVCB response, the
 client SHOULD wait up to CD milliseconds before connecting as if the
 SVCB query returned NODATA, but MUST NOT transmit any information that
 could be altered by an SVCB response until the SVCB response arrives.
-For example, a TLS connection may be altered by the "esnikeys" value
-of an SVCB response. CD (Connection Delay) is a configurable parameter.
-The recommended value is 50 milliseconds, as per the guidance in {{!HappyEyeballsV2=RFC8305}}.
+For example, a TLS ClientHello may be altered by the "esnikeys" value
+of an SVCB response {{svcparamkeys-esnikeys}}. CD (Connection Delay)
+is a configurable parameter. The recommended value is 50 milliseconds,
+as per the guidance in {{!HappyEyeballsV2=RFC8305}}.
 
-If an SVCB record is consistent with an active or in-progress connection,
-the client may continue using that connection using any information provided
-by the SVCB RR. For example, if an SVCB record with a "esnikeys" value and
-"ipv4hint" or "ipv6hint" values arrives and one of those hints matches the
-address of an in-progress connection, the TLS connection should proceed using
-the provided ESNI keying material.
+An SVCB record is consistent with an active or in-progress connection C
+if the A or AAAA address for its SvcDomainName matches the destination
+address of C. If an SVCB record is consistent with an active or in-progress
+connection C, the client may continue using C with any information provided
+by the SVCB record. For example, if an SVCB record with a "esnikeys" value and
+"ipv4hint" or "ipv6hint" values {{svcparamkeys-iphints}} arrives, and one of
+those hints matches the address of an in-progress connection TCP connection,
+TLS should proceed on that connection using the provided ESNI keying material.
 
 If the SVCB record is not consistent with any active or in-progress connection,
-e.g. there is no "ipv4hint" or "ipv6hint" that matches a connection, clients must
-then resolve the SvcDomainName in the SVCB response to the preferred A or AAAA
-adddress. If a client's DNS cache has valid A or AAAA records for the SvcDomainName,
-those SHOULD be used. Otherwise, clients MUST resolve SvcDomainName to according to
-the procedure in {{client-behavior}}.
+clients must then resolve the SvcDomainName in the SVCB response to the preferred
+A or AAAA adddress. If a client's DNS cache has valid A or AAAA records for the
+SvcDomainName, those SHOULD be used. Otherwise, clients MUST resolve SvcDomainName
+to according to the procedure in {{client-behavior}}.
 
 A nonconforming recursive resolver might not return all the information
 required to use all the records in an SVCB response.  If
-some of the SVCB RRs in the response can be used without requiring
-additional DNS queries, the client MAY prefer those RRs, regardless of
+some of the SVCB records in the response can be used without requiring
+additional DNS queries, the client MAY prefer those records, regardless of
 their priorities.
 
 To avoid a delay for clients using a nonconforming recursive resolver,
@@ -694,7 +696,7 @@ is the corresponding 2 octet numeric value in network byte order.
 The SvcParamKey for ESNI is "esnikeys".  Its value is defined in
 {{esnikeys}}.  It is applicable to most TLS-based protocols.
 
-## "ipv4hint" and "ipv6hint"
+## "ipv4hint" and "ipv6hint" {#svcparamkeys-iphints}
 
 The "ipv4hint" and "ipv6hint" keys represent IP address hints for the service.
 If A and AAAA records for SvcDomainName are locally available, the client SHOULD

--- a/draft-nygren-dnsop-svcb-httpssvc.md
+++ b/draft-nygren-dnsop-svcb-httpssvc.md
@@ -628,7 +628,7 @@ With these optimizations in place, and conforming DNS servers,
 using SVCB does not add network latency to connection setup.
 
 Moreover, if an A or AAAA response arrives before an SVCB response, the
-client MAY wait up to CD milliseconds before connecting as if the
+client MAY wait at least CD milliseconds before connecting as if the
 SVCB query returned NODATA, but MUST NOT transmit any information that
 could be altered by an SVCB response until the SVCB response arrives.
 For example, a TLS ClientHello may be altered by the "esnikeys" value
@@ -649,12 +649,8 @@ by the SVCB record. For example, if an SVCB record with a "esnikeys" value and
 "ipv4hint" or "ipv6hint" values {{svcparamkeys-iphints}} arrives, and one of
 those hints matches the address of an in-progress connection TCP connection,
 TLS should proceed on that connection using the provided ESNI keying material.
-
 If the SVCB record is not consistent with any active or in-progress connection,
-clients must then resolve the SvcDomainName in the SVCB response to the preferred
-A or AAAA adddress. If a client's DNS cache has valid A or AAAA records for the
-SvcDomainName, those SHOULD be used. Otherwise, clients MUST resolve SvcDomainName
-to according to the procedure in {{client-behavior}}.
+clients must proceed as described in Step 3 of the procedure in {{client-behavior}}.
 
 A nonconforming recursive resolver might not return all the information
 required to use all the records in an SVCB response.  If

--- a/draft-nygren-dnsop-svcb-httpssvc.md
+++ b/draft-nygren-dnsop-svcb-httpssvc.md
@@ -636,14 +636,9 @@ of an SVCB response {{svcparamkeys-esnikeys}}. CD (Connection Delay)
 is a configurable parameter. The recommended value is 50 milliseconds,
 as per the guidance in {{!HappyEyeballsV2=RFC8305}}.
 
-An SVCB record is consistent with an active or in-progress connection C
-if the following conditions are met:
-
-1. The A or AAAA address for its SvcDomainName matches the destination
-address of C.
-2. The destination port of C matches that specified in the SVCB record.
-
-If an SVCB record is consistent with an active or in-progress
+An SVCB record is consistent with an active or in-progress connection
+if the client would attempt an equivalent connection when making use of
+that record. If an SVCB record is consistent with an active or in-progress
 connection C, the client may continue using C with any information provided
 by the SVCB record. For example, if an SVCB record with a "esnikeys" value and
 "ipv4hint" or "ipv6hint" values {{svcparamkeys-iphints}} arrives, and one of


### PR DESCRIPTION
We have text in the ESNI draft which describes what to do when A/AAAA arrives before ESNI (equivalently SVCB). This attempts to port that text over. Please have a look!

@enygren @MikeBishop @bemasc 