### PR TITLE
Remove recommendation to shorten the TTL

### DIFF
--- a/draft-ietf-dnsop-svcb-httpssvc.md
+++ b/draft-ietf-dnsop-svcb-httpssvc.md
@@ -851,8 +851,8 @@ HTTPSSVC records expiring on time.  Shortening the TTL to compensate
 for incorrect caching is NOT RECOMMENDED, as this practice impairs the
 performance of correctly functioning caches and does not guarantee
 faster expiration from incorrect caches.  Instead, server operators
-SHOULD continue operating the endpoints in expired records until they
-observe that nearly all connections have migrated to the new endpoints.
+SHOULD maintain compatibility with expired records until they observe
+that nearly all connections have migrated to the new configuration.
 
 Sending Alt-Svc over HTTP allows the server to tailor the Alt-Svc
 Field Value specifically to the client.  When using an HTTPSSVC DNS

--- a/draft-ietf-dnsop-svcb-httpssvc.md
+++ b/draft-ietf-dnsop-svcb-httpssvc.md
@@ -843,9 +843,11 @@ this parameter is not safe to accept over an untrusted channel.
 There is no SvcParamKey corresponding to the Alt-Svc "ma" (max age) parameter.
 Instead, server operators SHOULD encode the expiration time in the DNS TTL.
 
-Some DNS caching systems incorrectly extend the lifetime of DNS
-records beyond the stated TTL.  Server operators MUST NOT rely on
-HTTPSSVC records expiring on time, and MAY shorten the TTL to compensate.
+The appropriate TTL value will typically be similar to the "ma" value
+used for Alt-Svc, but may vary depending on the desired efficiency and
+agility.  Some DNS caching systems incorrectly extend the lifetime of DNS
+records beyond the stated TTL, so server operators MUST NOT rely on
+HTTPSSVC records expiring on time.
 
 Sending Alt-Svc over HTTP allows the server to tailor the Alt-Svc
 Field Value specifically to the client.  When using an HTTPSSVC DNS

--- a/draft-ietf-dnsop-svcb-httpssvc.md
+++ b/draft-ietf-dnsop-svcb-httpssvc.md
@@ -845,9 +845,14 @@ Instead, server operators SHOULD encode the expiration time in the DNS TTL.
 
 The appropriate TTL value will typically be similar to the "ma" value
 used for Alt-Svc, but may vary depending on the desired efficiency and
-agility.  Some DNS caching systems incorrectly extend the lifetime of DNS
-records beyond the stated TTL, so server operators MUST NOT rely on
-HTTPSSVC records expiring on time.
+agility.  Some DNS caches incorrectly extend the lifetime of DNS
+records beyond the stated TTL, so server operators cannot rely on
+HTTPSSVC records expiring on time.  Shortening the TTL to compensate
+for incorrect caching is NOT RECOMMENDED, as this practice impairs the
+performance of correctly functioning caches and does not guarantee
+faster expiration from incorrect caches.  Instead, server operators
+SHOULD continue operating the endpoints in expired records until they
+observe that nearly all connections have migrated to the new endpoints.
 
 Sending Alt-Svc over HTTP allows the server to tailor the Alt-Svc
 Field Value specifically to the client.  When using an HTTPSSVC DNS


### PR DESCRIPTION
Shortening the TTL doesn't actually solve the problem,
because some caches ignore small TTL values.  Regardless of TTL,
servers have to be able to deal with occasional use of expired
records.  Shortening TTL is also bad for efficiency, so we
shouldn't encourage it.

Fixes #74