### PR TITLE
Do not allow duplicate ipv4hint and ipv6hint parameters

### DIFF
--- a/draft-ietf-dnsop-svcb-httpssvc.md
+++ b/draft-ietf-dnsop-svcb-httpssvc.md
@@ -750,9 +750,6 @@ The wire format for each parameter is a sequence of IP addresses in network
 byte order.  Like an A or AAAA RRSet, the list of addresses represents an
 unordered collection, and clients SHOULD pick addresses to use in a random order.
 
-These parameters MAY be repeated multiple times within a record.
-When receiving such a record, clients SHOULD combine the sets of addresses.
-
 When selecting between IPv4 and IPv6 addresses to use, clients may use an
 approach such as {{!HappyEyeballsV2=RFC8305}}.
 When only "ipv4hint" parameters are present, IPv6-only clients may synthesize


### PR DESCRIPTION
The contents already encode multiple addresses. We shouldn't have multiple ways to say the same thing.