### PR TITLE
Clarify serialization of values of unknown SvcParamKeys

### DIFF
--- a/draft-ietf-dnsop-svcb-httpssvc.md
+++ b/draft-ietf-dnsop-svcb-httpssvc.md
@@ -393,6 +393,14 @@ In presentation format, values of unrecognized keys
 SHALL be represented in wire format, using decimal escape codes
 (e.g. \255) when necessary.
 
+When decoding values of unrecognized keys in the presentation format:
+
+* a character other than "\" represents its ASCII value in wire format.
+* the character "\" followed by three decimal digits, up to 255, represents
+  an octet in the wire format.
+* the character "\" followed by any allowed character, except a decimal digit,
+  represents the subsequent character's ASCII value.
+
 Elements in presentation format MAY appear in any order.
 
 ## SVCB RDATA Wire Format
@@ -425,7 +433,7 @@ Clients MUST consider an RR malformed if
 
 * the parser reaches the end of the RDATA while parsing a SvcFieldValue.
 * SvcParamKeys are not in strictly increasing numeric order.
-* a SvcParamValue for a known SvcParamKey does not have the expected format.
+* the SvcParamValue for an SvcParamKey does not have the expected format.
 
 Note that the second condition implies that there are no duplicate
 SvcParamKeys.

--- a/draft-ietf-dnsop-svcb-httpssvc.md
+++ b/draft-ietf-dnsop-svcb-httpssvc.md
@@ -401,7 +401,8 @@ When decoding values of unrecognized keys in the presentation format:
 * the character "\" followed by any allowed character, except a decimal digit,
   represents the subsequent character's ASCII value.
 
-Elements in presentation format MAY appear in any order.
+Elements in presentation format MAY appear in any order, but keys MUST NOT be
+repeated.
 
 ## SVCB RDATA Wire Format
 
@@ -812,13 +813,13 @@ more `alpn-id`s.  Any commas present in the protocol-id are escaped
 by a backslash:
 
     escaped-octet = %x00-2b / "\," / %x2d-5b / "\\" / %x5D-FF
-    escaped-id = 1*255(escaped-octet)
+    escaped-id = 1*(escaped-octet)
     alpn-value = escaped-id *("," escaped-id)
 
-In the wire format for "alpn", each ALPN identifier (`alpn-id`) is prefixed by its
-length as a single octet, and these length-value pairs are concatenated
-to form the SvcParamValue.  These pairs MUST exactly fill the SvcParamValue;
-otherwise, the SvcParamValue is malformed.
+The wire format value for "alpn" consists of at least one ALPN identifier
+(`alpn-id`) prefixed by its length as a single octet, and these length-value
+pairs are concatenated to form the SvcParamValue.  These pairs MUST exactly
+fill the SvcParamValue; otherwise, the SvcParamValue is malformed.
 
 For "no-default-alpn", the presentation and wire format values MUST be
 empty.

--- a/draft-ietf-dnsop-svcb-httpssvc.md
+++ b/draft-ietf-dnsop-svcb-httpssvc.md
@@ -130,7 +130,7 @@ parameter specification, similar to HTTPSSVC.
 TO BE REMOVED: Another open question is whether SVCB records
 should be self-descriptive and include the service name
 (eg, "https") in the RDATA section to avoid ambiguity.
-Perhaps this could be included as a svc="baz" parameter
+Perhaps this could be included as an svc="baz" parameter
 for protocols that are not the default for the RR type?
 Current inclination is to not do so.
 
@@ -309,7 +309,7 @@ For consistency with {{AltSvc}}, we adopt the following definitions:
   origin over a specified protocol.
 
 For example within HTTPS, the origin consists of a scheme (typically
-"https"), a host name, and a port (typically "443").
+"https"), a hostname, and a port (typically "443").
 
 Additional DNS terminology intends to be consistent
 with {{?DNSTerm=RFC8499}}.
@@ -346,7 +346,7 @@ the Internet ("IN") Class ({{!RFC1035}}).
 SvcFieldPriority is a number in the range 0-65535,
 SvcDomainName is a domain name,
 and SvcFieldValue is a set of key=value pairs present for the ServiceForm.
-Each key SHALL appear at most once in a SvcFieldValue.
+Each key SHALL appear at most once in an SvcFieldValue.
 The SvcFieldValue is empty for the AliasForm.
 
 ### Presentation format for SvcFieldValue key=value pairs {#svcfieldvalue}
@@ -389,7 +389,7 @@ of a value is not limited to 255 characters.)
 Unrecognized keys are represented in presentation
 format as "keyNNNNN" where NNNNN is the numeric
 value of the key type without leading zeros.
-In presentation format, values of unrecognized keys
+In presentation format, values corresponding to unrecognized keys
 SHALL be represented in wire format, using decimal escape codes
 (e.g. \255) when necessary.
 
@@ -431,7 +431,7 @@ SvcParamKeys SHALL appear in increasing numeric order.
 
 Clients MUST consider an RR malformed if
 
-* the parser reaches the end of the RDATA while parsing a SvcFieldValue.
+* the parser reaches the end of the RDATA while parsing an SvcFieldValue.
 * SvcParamKeys are not in strictly increasing numeric order.
 * the SvcParamValue for an SvcParamKey does not have the expected format.
 
@@ -451,7 +451,7 @@ ignore-just-param-if-unknown.
 
 When querying the SVCB RR, an origin is typically translated into a QNAME
 by prefixing the port and scheme with "_", then concatenating them with the
-host name, resulting in a domain name like "_8004._examplescheme.api.example.com.".
+hostname, resulting in a domain name like "_8004._examplescheme.api.example.com.".
 
 Protocol mappings for SVCB MAY remove the port or replace it with other
 protocol-specific information, but MUST retain the scheme in the QNAME.
@@ -963,7 +963,7 @@ The HTTPSSVC RR extends the behavior for determining
 a QNAME specified above in {{svcb-names}}.
 In particular, if the scheme is "https" with port 443
 then the client's original QNAME is
-equal to the origin host name.
+equal to the origin hostname.
 
 By removing the {{?Attrleaf}} labels
 used in SVCB, this construction enables offline DNSSEC signing of
@@ -1165,7 +1165,7 @@ track users or hinder their connections after they leave that network.
 
 ## New registry for Service Parameters {#svcparamregistry}
 
-The "Service Binding (SVCB) Parameter Registry" defines the name space
+The "Service Binding (SVCB) Parameter Registry" defines the namespace
 for parameters, including string representations and numeric
 SvcParamKey values.  This registry is shared with other SVCB-compatible
 RR types, such as HTTPSSVC.
@@ -1181,7 +1181,7 @@ A registration MUST include the following fields:
 * Meaning: a short description
 * Pointer to specification text
 
-Values to be added to this name space require Expert Review (see
+Values to be added to this namespace require Expert Review (see
 {{!RFC5226}}, Section 4.1).  Apart from the initial contents, the name
 MUST NOT start with "key".
 
@@ -1268,7 +1268,7 @@ Unlike {{?I-D.draft-bellis-dnsop-http-record-00}}, this approach is
 extensible to cover Alt-Svc and ESNI use-cases.  Like that
 proposal, this addresses the zone apex CNAME challenge.
 
-Like that proposal it remains necessary to continue to include
+Like that proposal, it remains necessary to continue to include
 address records at the zone apex for legacy clients.
 
 
@@ -1282,7 +1282,7 @@ master servers, beyond optionally returning in-bailiwick additional records.
 Like that proposal, this addresses the zone apex CNAME challenge
 for clients that implement this.
 
-However with this SVCB proposal it remains necessary to continue
+However, with this SVCB proposal, it remains necessary to continue
 to include address records at the zone apex for legacy clients.
 If deployment of this standard is successful, the number of legacy clients
 will fall over time.  As the number of legacy clients declines, the operational


### PR DESCRIPTION
I've added the following:

```
When decoding values of unrecognized keys in the presentation format:

* a character other than "\" represents its ASCII value in wire format.
* the character "\" followed by three decimal digits, up to 255, represents
  an octet in the wire format.
* the character "\" followed by any allowed character, except a decimal digit,
  represents the subsequent character's ASCII value.

```
and some other changes as discussed with bemasc in https://github.com/MikeBishop/dns-alt-svc/pull/140/commits/c69812c542fcdce466717f2f55e6ec0a5966e740

Possible todo:
TODO remove outside ascii characters from alpn, inherit escaping from values of private keys

---
Resolved questions:

And escaped alpn values in the presentation format can contain characters outside the ASCII range, non-visible characters or even the null character. Should I change that too?

Moreover, some alpn values are in the gray area: They fit in 255 octets in wire format, but they are longer than 255 characters in the presentation format. (For example `,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,`) We should ban those alpn values too?

Similarly, *The presentation value of "alpn" is a comma-separated list of one or more "alpn-id"s.*, It should say at least one alpn value for the wire format as well?

And since there's no requirement about the order of the pairs in the presentation format, duplicate pairs are allowed?

---
and I would like to add [my implementation](https://github.com/miekg/dns/pull/1067) and [this implementation](https://github.com/rthalley/dnspython/pull/452) to the list. That should be a separate pull request?