### PR TITLE
Adjust CamelCase names

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -114,6 +114,12 @@ and introductory examples, much of this document refers only to the SVCB RR,
 but those references should be taken to apply to SVCB, HTTPS,
 and any future SVCB-compatible RR types.
 
+The SVCB RR has two modes: 1) "AliasMode" simply delegates operational
+control for a resource; 2) "ServiceMode" binds together
+configuration information for a service endpoint.
+ServiceMode provides additional key=value parameters
+within each RDATA set.
+
 TO BE REMOVED: If we use this for providing configuration for DNS
 authorities, it is likely we'd specify a distinct "NS2" RR type that is
 an instantiation of SVCB for authoritative nameserver delegation and
@@ -259,7 +265,8 @@ the Internet ("IN") Class ({{!RFC1035}}).
 
 SvcPriority is a number in the range 0-65535,
 TargetName is a domain name,
-and the SvcParams are SvcParamKey=SvcParamValue pairs separated by whitespace.
+and the SvcParams are a whitespace-separated list, with each SvcParam
+consisting of a SvcParamKey=SvcParamValue pair or a standalone SvcParamKey.
 SvcParamKeys are subject to IANA control ({{svcparamregistry}}).
 
 Each SvcParamKey SHALL appear at most once in the SvcParams.
@@ -436,7 +443,7 @@ the target of the SVCB record might offer better performance, and
 therefore would be preferable for clients implementing this specification
 to use.
 
-SVCB and SVCB-compatible record types use AliasMode only within the type.
+AliasMode records only apply to queries for the specific RR type.
 For example, a SVCB record cannot alias to an HTTPS record,
 nor vice-versa.
 
@@ -1314,7 +1321,7 @@ ACTION: create and include a reference to this registry.
 A registration MUST include the following fields:
 
 * Number: SvcParamKey wire format numeric identifier (range 0-65535)
-* Name: Service parameter key name
+* Name: SvcParamKey presentation name
 * Meaning: a short description
 * Pointer to specification text
 

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -173,8 +173,9 @@ The SVCB RR has two mandatory fields and one optional.  The fields are:
 2. TargetName: The domain name of either the alias target (for
    AliasMode) or the alternative service endpoint (for ServiceMode).
 3. SvcParams (optional): A list of key=value pairs
-   describing the alternative service endpoint at
-   TargetName (only used in ServiceMode and otherwise ignored).
+   describing the alternative endpoint at
+   TargetName (only used in ServiceMode and otherwise ignored). 
+   Described in {{svcparams}}.
 
 Cooperating DNS recursive resolvers will perform subsequent record
 resolution (for SVCB, A, and AAAA records) and return them in the
@@ -940,7 +941,7 @@ origin hostname also allows the targets of existing CNAME chains
 requiring origin domains to configure and maintain an additional
 delegation.
 
-Following of HTTPS RR aliases and CNAME aliases is unchanged from SVCB.
+Following of HTTPS AliasMode RRs and CNAME aliases is unchanged from SVCB.
 
 Clients always convert "http" URLs to "https" before performing an
 HTTPS RR query using the process described in {{hsts}}, so domain owners

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -441,8 +441,7 @@ nor vice-versa.
 
 ### ServiceMode
 
-In ServiceMode, the
-TargetName and SvcParams within each resource record
+In ServiceMode, the TargetName and SvcParams within each resource record
 associate an alternative service location with its connection parameters.
 
 Each protocol scheme that uses SVCB MUST define a protocol mapping that
@@ -694,9 +693,9 @@ domain owners SHOULD set TargetName to
 address records are already present in the client's DNS cache as part of the
 responses to the address queries that were issued in parallel.
 
-# Initial keys {#keys}
+# Initial SvcParam keys {#keys}
 
-A few initial keys are defined here.  These keys are useful for
+A few initial SvcParam keys are defined here.  These keys are useful for
 HTTPS, and most are applicable to other protocols as well.
 
 ## "alpn" and "no-default-alpn" {#alpn-key}

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -1342,7 +1342,7 @@ A registration MUST include the following fields:
 * Meaning: a short description
 * Pointer to specification text
 
-SvcParamKey values to be added to this namespace
+SvcParamKey entries to be added to this namespace
 have different policies ({{!RFC5226}}, Section 4.1)
 based on their range:
 

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -271,7 +271,7 @@ In ABNF {{!RFC5234}},
     SvcParamKey = 1*(ALPHA-LC / DIGIT / "-")
     display-key = 1*(ALPHA / DIGIT / "-")
 
-Values are in a format specific to the key.
+Values are in a format specific to the SvcParamKey.
 Their definition should specify both their presentation format
 and wire encoding (e.g., domain names, binary data, or numeric values).
 The initial keys and formats are defined in {{keys}}.
@@ -1313,7 +1313,7 @@ ACTION: create and include a reference to this registry.
 
 A registration MUST include the following fields:
 
-* Number: Service parameter key numeric identifier (range 0-65535)
+* Number: SvcParamKey wire format numeric identifier (range 0-65535)
 * Name: Service parameter key name
 * Meaning: a short description
 * Pointer to specification text

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -258,10 +258,10 @@ the Internet ("IN") Class ({{!RFC1035}}).
 
 SvcPriority is a number in the range 0-65535,
 TargetName is a domain name,
-and the SvcParams are represented as a whitespace-separated list.
+and the SvcParams are key=value pairs separated by whitespace.
 Keys are subject to IANA control ({{svcparamregistry}}).
 
-Each key SHALL appear at most once in a SvcParams.
+Each key SHALL appear at most once in the SvcParams.
 In presentation format, keys are case-insensitive alphanumeric strings.
 Key names should only contain characters from the ranges "a"-"z", "0"-"9", and "-".
 In ABNF {{!RFC5234}},


### PR DESCRIPTION
This (purely editorial) change replaces the unambiguous but
idiosyncratic CamelCase terms with capitalized standard terms.
It also removes some duplicated language and changes "form" to "mode",
since there is really only one SVCB wire format.

Relevant issues: #99, #82