### PR TITLE
Incorporate comments from implementer review

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -596,8 +596,7 @@ Providing the proxy with the final SvcDomainName has several benefits:
 ## Authoritative servers
 
 When replying to a SVCB query, authoritative DNS servers SHOULD return
-A, AAAA, and SVCB records (as well as following any relevant CNAME or
-{{!DNAME=RFC6672}} records) in the Additional Section for any
+A, AAAA, and SVCB records in the Additional Section for any
 in-bailiwick SvcDomainNames.  If the zone is signed, the server SHOULD also
 include positive or negative DNSSEC responses for these records in the Additional
 section.
@@ -605,8 +604,8 @@ section.
 ## Recursive resolvers {#recursive-behavior}
 
 Recursive resolvers that are aware of SVCB SHOULD help the client to
-execute the procedure in {{client-behavior}} without issuing a second
-round of queries, by incorporating additional useful information into the
+execute the procedure in {{client-behavior}} with minimum overall
+latency, by incorporating additional useful information into the
 response.  For the initial SVCB record query, this is just the normal
 response construction process (i.e. unknown RR type resolution under
 {{!RFC3597}}).  For followup resolutions performed during this procedure,
@@ -637,9 +636,9 @@ construct the full response to the stub resolver:
 In this procedure, "resolve" means the resolver's ordinary recursive
 resolution procedure, as if processing a query for that RRSet.
 This includes following any aliases that the resolver would ordinarily
-follow (e.g. CNAME, {{!DNAME}}).
+follow (e.g. CNAME, {{!DNAME=RFC6672}}).
 
-See {{incomplete-responses}} for possible optimizations of this procedure.
+See {{incomplete-response}} for possible optimizations of this procedure.
 
 ## General requirements
 

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -639,7 +639,7 @@ resolution procedure, as if processing a query for that RRSet.
 This includes following any aliases that the resolver would ordinarily
 follow (e.g. CNAME, {{!DNAME}}).
 
-See {{#incomplete-responses}} for possible optimizations of this procedure.
+See {{incomplete-responses}} for possible optimizations of this procedure.
 
 ## General requirements
 

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -596,20 +596,22 @@ Providing the proxy with the final SvcDomainName has several benefits:
 ## Authoritative servers
 
 When replying to a SVCB query, authoritative DNS servers SHOULD return
-A, AAAA, and SVCB records (as well as any relevant CNAME or
+A, AAAA, and SVCB records (as well as following any relevant CNAME or
 {{!DNAME=RFC6672}} records) in the Additional Section for any
-in-bailiwick SvcDomainNames.
+in-bailiwick SvcDomainNames.  If the zone is signed, the server SHOULD also
+include positive or negative DNSSEC responses for these records in the Additional
+section.
 
 ## Recursive resolvers {#recursive-behavior}
 
-Recursive resolvers that are aware of SVCB SHOULD ensure that the client can
+Recursive resolvers that are aware of SVCB SHOULD help the client to
 execute the procedure in {{client-behavior}} without issuing a second
-round of queries, by incorporating all the necessary information into a
-single response.  For the initial SVCB record query, this is just the normal
+round of queries, by incorporating additional useful information into the
+response.  For the initial SVCB record query, this is just the normal
 response construction process (i.e. unknown RR type resolution under
 {{!RFC3597}}).  For followup resolutions performed during this procedure,
-we define incorporation as adding all Answer and Additional RRs to the
-Additional section, and all Authority RRs to the Authority section,
+we define incorporation as adding all useful RRs from the response to the
+Additional section
 without altering the response code.
 
 Upon receiving a SVCB query, recursive resolvers SHOULD start with the
@@ -636,6 +638,8 @@ In this procedure, "resolve" means the resolver's ordinary recursive
 resolution procedure, as if processing a query for that RRSet.
 This includes following any aliases that the resolver would ordinarily
 follow (e.g. CNAME, {{!DNAME}}).
+
+See {{#incomplete-responses}} for possible optimizations of this procedure.
 
 ## General requirements
 


### PR DESCRIPTION
We got some tweaks from a server implementer review
* Everything additional should go in Additional
* Authoritatives should include DNSSEC for the in-bailiwick followup records
* Harmonize #recursive-behavior with #incomplete-responses