### PR TITLE
Proposal: Skip the default port prefix

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -351,7 +351,7 @@ resulting in a domain name like "_examplescheme.api.example.com.".
 Protocol mapping documents MAY specify additional underscore-prefixed labels
 to be prepended.  For schemes that specify a port (Section 3.2.3
 of {{?URI=RFC3986}}), one reasonable possibility is to prepend the indicated port
-number (or the default if no port number is specified).  We term this behavior
+number if a non-default port number is specified.  We term this behavior
 "Port Prefix Naming", and use it in the examples throughout this document.
 
 See {{httpsnames}} for the HTTPS RR behavior.


### PR DESCRIPTION
This changes the definition of "Port Prefix Naming" to only include the
_port prefix if a non-default port is specified.  None of the examples
exercise this case, and the HTTPS RR overrides it, so this only matters
for future protocol mappings that choose to follow this advice.