### PR TITLE
Update iOS description for production version

### DIFF
--- a/svcb-implementations.md
+++ b/svcb-implementations.md
@@ -54,9 +54,10 @@ These were found by some web searches so you milage may vary:
 
 ## iOS & macOS ##
 
-The betas of iOS 14 and macOS 11 contain support for HTTPS/SVCB records. Support for draft-ietf-dnsop-svcb-https-01
-using types 64/65 is enabled starting in Beta 4. Connections that use URLSession or Network.framework automatically
-request HTTPS records alongside A and AAAA records when using an http or https scheme, or on ports 80 or 443. 
+iOS 14 supports HTTPS/SVCB records as defined in draft-ietf-dnsop-svcb-https-01. Type 65 (HTTPS) is requested
+for all URLSession or Network.framework connections that use an http or https scheme, or use ports 80 or 443.
+
+Betas of macOS 11 support the same, since beta 4.
 
 # Services using and/or announced support for SVCB/HTTPS records #
 


### PR DESCRIPTION
iOS 14 has shipped the official version, with support for SVCB/HTTPS records.