### PR TITLE
Proposal: Recommend not exceeding chain length 8

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -1196,6 +1196,8 @@ foo://foo.example.com:8080, this might look like:
 
 Domain owners SHOULD avoid using a TargetName that is below a DNAME, as
 this is likely unnecessary and makes responses slower and larger.
+Also, zone structures that require following more than 8 aliases
+(counting both AliasMode and CNAME records) are NOT RECOMMENDED.
 
 ## Examples
 


### PR DESCRIPTION
This change instructs zone operators not to create excessively long
alias chains.  This change does not affect the normative requirements
for resolvers, which are only required to follow at least one AliasMode
alias.