### PR TITLE
DNS for SVCB-reliant proxy usage

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -573,11 +573,11 @@ destinations with a proxy that does not provide SVCB query capability
 (e.g. through an affiliated DNS resolver), the client would have to perform
 SVCB queries though a separate resolver.  This might disclose the client's
 destinations to an additional party, creating privacy concerns.  If these
-concerns apply, SVCB-optional clients SHOULD disable SVCB resolution.
-SVCB-reliant clients cannot function in this configuration, so they must
-arrange for SVCB resolution with appropriate privacy and routing properties.
-such as by issuing the SVCB DNS lookups through a proxy (as will be needed
-by SVCB-reliant clients).
+concerns apply, SVCB-optional clients SHOULD disable SVCB resolution
+unless they arrange for SVCB resolution with appropriate privacy 
+and routing properties.  As SVCB-reliant clients cannot function in this 
+configuration, they must arrange for SVCB resolution with appropriate 
+privacy and routing properties.
 
 If the client does use SVCB and named destinations, the client SHOULD follow
 the standard SVCB resolution process, selecting the smallest-SvcPriority

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -573,11 +573,9 @@ destinations with a proxy that does not provide SVCB query capability
 (e.g. through an affiliated DNS resolver), the client would have to perform
 SVCB queries though a separate resolver.  This might disclose the client's
 destinations to an additional party, creating privacy concerns.  If these
-concerns apply, SVCB-optional clients SHOULD disable SVCB resolution
-unless they arrange for SVCB resolution with appropriate privacy 
-and routing properties.  As SVCB-reliant clients cannot function in this 
-configuration, they must arrange for SVCB resolution with appropriate 
-privacy and routing properties.
+Clients that support such proxies SHOULD arrange for a separate SVCB resolution
+procedure with appropriate privacy properties, or disable SVCB resolution entirely if
+SVCB-optional.
 
 If the client does use SVCB and named destinations, the client SHOULD follow
 the standard SVCB resolution process, selecting the smallest-SvcPriority

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -573,7 +573,9 @@ destinations with a proxy that does not provide SVCB query capability
 (e.g. through an affiliated DNS resolver), the client would have to perform
 SVCB queries though a separate resolver.  This might disclose the client's
 destinations to an additional party, creating privacy concerns.  If these
-concerns apply, the client SHOULD disable SVCB resolution.
+concerns apply, the client SHOULD mitigate these concerns in some way,
+such as by issuing the SVCB DNS lookups through a proxy (as will be needed
+by SVCB-reliant clients).
 
 If the client does use SVCB and named destinations, the client SHOULD follow
 the standard SVCB resolution process, selecting the smallest-SvcPriority

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -571,8 +571,7 @@ use named destinations, in which case the client does not perform
 any A or AAAA queries for destination domains.  If the client is using named
 destinations with a proxy that does not provide SVCB query capability
 (e.g. through an affiliated DNS resolver), the client would have to perform
-SVCB queries though a separate resolver.  This might disclose the client's
-destinations to an additional party, creating privacy concerns.  If these
+SVCB resolution separately, likely disclosing the destinations to additional parties.
 Clients that support such proxies SHOULD arrange for a separate SVCB resolution
 procedure with appropriate privacy properties, or disable SVCB resolution entirely if
 SVCB-optional.

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -573,7 +573,9 @@ destinations with a proxy that does not provide SVCB query capability
 (e.g. through an affiliated DNS resolver), the client would have to perform
 SVCB queries though a separate resolver.  This might disclose the client's
 destinations to an additional party, creating privacy concerns.  If these
-concerns apply, the client SHOULD mitigate these concerns in some way,
+concerns apply, SVCB-optional clients SHOULD disable SVCB resolution.
+SVCB-reliant clients cannot function in this configuration, so they must
+arrange for SVCB resolution with appropriate privacy and routing properties.
 such as by issuing the SVCB DNS lookups through a proxy (as will be needed
 by SVCB-reliant clients).
 


### PR DESCRIPTION
Addresses one aspect of #293

Do we need to give more details on how a proxy might be used for DNS lookups (eg, to a DoH server) or is this fine as-is?  Should this be non-normative?