### PR TITLE
Using TargetName to a proxy should be a MUST

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -579,7 +579,7 @@ SVCB-optional.
 If the client does use SVCB and named destinations, the client SHOULD follow
 the standard SVCB resolution process, selecting the smallest-SvcPriority
 option that is compatible with the client and the proxy.  When connecting
-using an SVCB record, clients MUST provide the final TargetName and port to the
+using a SVCB record, clients MUST provide the final TargetName and port to the
 proxy, which will perform any required A and AAAA lookups.
 
 Providing the proxy with the final TargetName has several benefits:

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -578,8 +578,8 @@ SVCB-optional.
 
 If the client does use SVCB and named destinations, the client SHOULD follow
 the standard SVCB resolution process, selecting the smallest-SvcPriority
-option that is compatible with the client and the proxy.  The client
-SHOULD provide the final TargetName and port to the
+option that is compatible with the client and the proxy.  When connecting
+using an SVCB record, clients MUST provide the final TargetName and port to the
 proxy, which will perform any required A and AAAA lookups.
 
 Providing the proxy with the final TargetName has several benefits:


### PR DESCRIPTION
When using a proxy with a SVCB record, using TargetName is a "MUST" as otherwise a client
might attempt to use parameters from a SVCB record with the service name which 
will not always work.