### PR TITLE
Specify interaction with ECS

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -597,11 +597,11 @@ Providing the proxy with the final TargetName has several benefits:
 
 # DNS Server Behavior {#server-behavior}
 
-## Authoritative servers
+## Authoritative servers {#authoritative-behavior}
 
 When replying to a SVCB query, authoritative DNS servers SHOULD return
-A, AAAA, and SVCB records in the Additional Section for any
-in-bailiwick TargetNames.  If the zone is signed, the server SHOULD also
+A, AAAA, and SVCB records in the Additional Section for any TargetNames
+that are in the zone.  If the zone is signed, the server SHOULD also
 include positive or negative DNSSEC responses for these records in the Additional
 section.
 
@@ -659,6 +659,31 @@ each RRSet in the Additional section with the same DNSSEC-related records
 that they would send when providing that RRSet as an Answer (e.g. RRSIG, NSEC,
 NSEC3).
 
+## EDNS Client Subnet (ECS)
+
+The EDNS Client Subnet extension (ECS, {{!RFC7871}}) allows recursive
+resolvers to request IP addresses that are suitable for a particular client
+IP range.  IP addresses appear in two places in Authoritative SVCB responses:
+
+* ipv*hint SvcParams in a ServiceMode response.  Clients only use these hints
+when the recursive resolver does not provide A/AAAA records for TargetName in
+the Additional section, as recommended in {{recursive-behavior}}.
+* A/AAAA records returned by the Authoritative server in the Additional
+section of a SVCB response when TargetName is in-zone, as recommended in
+{{authoritative-behavior}}.
+
+A recursive resolver that uses ECS for A/AAAA queries SHOULD send the
+same ECS prefix for SVCB queries unless it knows that any ipv*hint SvcParams
+will not be used, due to the resolver's implementation of Additional section
+processing.  To disable ECS for SVCB, such a resolver SHOULD include an ECS
+extension with a SOURCE PREFIX-LENGTH of zero, to indicate that ECS is
+supported but disabled.
+
+According to Section 7.3.1 of {{!RFC7871}}, "Any records from \[the
+Additional section\] MUST NOT be tied to a network".  Accordingly,
+when responding to a SVCB query with the ECS extension, Authoritative
+servers MAY omit these records to ensure that prefix-specific A/AAAA
+records are returned by a subsequent or parallel query.
 
 # Performance optimizations {#optimizations}
 

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -683,7 +683,7 @@ same ECS extension that it would use for an A/AAAA query.
 
 According to Section 7.3.1 of {{!RFC7871}}, "Any records from \[the
 Additional section\] MUST NOT be tied to a network".  Accordingly,
-Resolvers SHOULD assume that any A/AAAA records in the Additional section
+resolvers SHOULD assume that any A/AAAA records in the Additional section
 are network-invariant.  When responding to a SVCB query with an ECS
 extension (even one whose SOURCE PREFIX-LENGTH is zero), an Authoritative
 server SHOULD NOT add any A/AAAA records for TargetName to the response if

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -661,6 +661,14 @@ each RRSet in the Additional section with the same DNSSEC-related records
 that they would send when providing that RRSet as an Answer (e.g. RRSIG, NSEC,
 NSEC3).
 
+According to Section 5.4.1 of {{!RFC2181}}, "Unauthenticated RRs received
+and cached from ... the additional data section ... should not be cached in
+such a way that they would ever be returned as answers to a received query.
+They may be returned as additional information where appropriate.".
+Recursive resolvers therefore MAY cache records from the Additional section
+for use in populating Additional section responses, and MAY cache them
+for general use if they are authenticated by DNSSEC.
+
 ## EDNS Client Subnet (ECS) {#ecs}
 
 The EDNS Client Subnet option (ECS, {{!RFC7871}}) allows recursive
@@ -673,12 +681,11 @@ According to Section 7.3.1 of {{!RFC7871}}, "Any records from \[the
 Additional section\] MUST NOT be tied to a network".  Accordingly,
 resolvers SHOULD treat any records in the Additional section as having
 SOURCE PREFIX-LENGTH zero and SCOPE PREFIX-LENGTH as specified
-in the ECS option, and MAY cache them on this basis.  Authoritative
-servers MUST omit such records if they are not suitable
-for use by any stub resolvers that set SOURCE PREFIX-LENGTH to zero.
-This will cause the resolver to perform a followup query that can receive
-properly tailored ECS.  (This is similar to the usage of CNAME with ECS
-discussed in {{!RFC7871}} Section 7.2.1.)
+in the ECS option.  Authoritative servers MUST omit such records if they are
+not suitable for use by any stub resolvers that set SOURCE PREFIX-LENGTH to
+zero.  This will cause the resolver to perform a followup query that can
+receive properly tailored ECS.  (This is similar to the usage of CNAME with
+ECS discussed in {{!RFC7871}} Section 7.2.1.)
 
 Authoritative servers that omit Additional records can avoid the added
 latency of a followup query by following the advice in {{zone-performance}}.

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -672,18 +672,22 @@ the Additional section, as recommended in {{recursive-behavior}}.
 section of a SVCB response when TargetName is in-zone, as recommended in
 {{authoritative-behavior}}.
 
-A recursive resolver that uses ECS for A/AAAA queries SHOULD send the
-same ECS prefix for SVCB queries unless it knows that any ipv*hint SvcParams
-will not be used, due to the resolver's implementation of Additional section
-processing.  To disable ECS for SVCB, such a resolver SHOULD include an ECS
-extension with a SOURCE PREFIX-LENGTH of zero, to indicate that ECS is
-supported but disabled.
+SVCB records SHOULD NOT otherwise vary based on ECS.
+
+A recursive resolver that always returns A/AAAA records for TargetName in the
+Additional section, as recommended in {{recursive-behavior}}, SHOULD include
+an ECS extension with a SOURCE PREFIX-LENGTH of zero in SVCB queries, to
+indicate that ECS is supported but is disabled for this query.  If the
+resolver might not return these Additional records, it SHOULD send the
+same ECS extension that it would use for an A/AAAA query.
 
 According to Section 7.3.1 of {{!RFC7871}}, "Any records from \[the
 Additional section\] MUST NOT be tied to a network".  Accordingly,
-when responding to a SVCB query with the ECS extension, Authoritative
-servers MAY omit these records to ensure that prefix-specific A/AAAA
-records are returned by a subsequent or parallel query.
+Resolvers SHOULD assume that any A/AAAA records in the Additional section
+are network-invariant.  When responding to a SVCB query with an ECS
+extension (even one whose SOURCE PREFIX-LENGTH is zero), an Authoritative
+server SHOULD NOT add any A/AAAA records for TargetName to the response if
+TargetName has any A/AAAA records that are tied to a network.  
 
 # Performance optimizations {#optimizations}
 

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -661,7 +661,7 @@ NSEC3).
 
 ## EDNS Client Subnet (ECS)
 
-The EDNS Client Subnet extension (ECS, {{!RFC7871}}) allows recursive
+The EDNS Client Subnet option (ECS, {{!RFC7871}}) allows recursive
 resolvers to request IP addresses that are suitable for a particular client
 IP range.  IP addresses appear in two places in Authoritative SVCB responses:
 
@@ -676,16 +676,16 @@ SVCB records SHOULD NOT otherwise vary based on ECS.
 
 A recursive resolver that always returns A/AAAA records for TargetName in the
 Additional section, as recommended in {{recursive-behavior}}, SHOULD include
-an ECS extension with a SOURCE PREFIX-LENGTH of zero in SVCB queries, to
+an ECS option with a SOURCE PREFIX-LENGTH of zero in SVCB queries, to
 indicate that ECS is supported but is disabled for this query.  If the
 resolver might not return these Additional records, it SHOULD send the
-same ECS extension that it would use for an A/AAAA query.
+same ECS option that it would use for an A/AAAA query.
 
 According to Section 7.3.1 of {{!RFC7871}}, "Any records from \[the
 Additional section\] MUST NOT be tied to a network".  Accordingly,
 resolvers SHOULD assume that any A/AAAA records in the Additional section
 are network-invariant.  When responding to a SVCB query with an ECS
-extension (even one whose SOURCE PREFIX-LENGTH is zero), an Authoritative
+option (even one whose SOURCE PREFIX-LENGTH is zero), an Authoritative
 server SHOULD NOT add any A/AAAA records for TargetName to the response if
 TargetName has any A/AAAA records that are tied to a network.  
 

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -672,8 +672,10 @@ SHOULD include the same ECS option in SVCB queries as in A/AAAA queries.
 According to Section 7.3.1 of {{!RFC7871}}, "Any records from \[the
 Additional section\] MUST NOT be tied to a network".  Accordingly,
 resolvers SHOULD treat any records in the Additional section as having
-SCOPE PREFIX-LENGTH zero, and MAY cache them on this basis.  Authoritative
-servers MUST omit such records if they are not suitable for global use.
+SOURCE PREFIX-LENGTH zero and SCOPE PREFIX-LENGTH as specified
+in the ECS option, and MAY cache them on this basis.  Authoritative
+servers MUST omit such records if they are not suitable
+for use by any stub resolvers that set SOURCE PREFIX-LENGTH to zero.
 This will cause the resolver to perform a followup query that can receive
 properly tailored ECS.  (This is similar to the usage of CNAME with ECS
 discussed in {{!RFC7871}} Section 7.2.1.)

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -605,6 +605,8 @@ that are in the zone.  If the zone is signed, the server SHOULD also
 include positive or negative DNSSEC responses for these records in the Additional
 section.
 
+See {{ecs}} for exception.
+
 ## Recursive resolvers {#recursive-behavior}
 
 Recursive resolvers that are aware of SVCB SHOULD help the client to
@@ -659,7 +661,7 @@ each RRSet in the Additional section with the same DNSSEC-related records
 that they would send when providing that RRSet as an Answer (e.g. RRSIG, NSEC,
 NSEC3).
 
-## EDNS Client Subnet (ECS)
+## EDNS Client Subnet (ECS) {#ecs}
 
 The EDNS Client Subnet option (ECS, {{!RFC7871}}) allows recursive
 resolvers to request IP addresses that are suitable for a particular client
@@ -685,9 +687,10 @@ According to Section 7.3.1 of {{!RFC7871}}, "Any records from \[the
 Additional section\] MUST NOT be tied to a network".  Accordingly,
 resolvers SHOULD assume that any A/AAAA records in the Additional section
 are network-invariant.  When responding to a SVCB query with an ECS
-option (even one whose SOURCE PREFIX-LENGTH is zero), an Authoritative
-server SHOULD NOT add any A/AAAA records for TargetName to the response if
-TargetName has any A/AAAA records that are tied to a network.  
+option (even one whose SOURCE PREFIX-LENGTH is zero), Authoritative servers
+must omit such records if they wish to serve subnet-specific addresses.
+Such Authoritative servers can avoid the added latency of a followup query
+by setting TargetName to the value recommended in {{zone-performance}}.
 
 # Performance optimizations {#optimizations}
 

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -671,12 +671,15 @@ SHOULD include the same ECS option in SVCB queries as in A/AAAA queries.
 
 According to Section 7.3.1 of {{!RFC7871}}, "Any records from \[the
 Additional section\] MUST NOT be tied to a network".  Accordingly,
-resolvers SHOULD assume that any A/AAAA records in the Additional section
-are network-invariant.  When responding to a SVCB query with an ECS
-option (even one whose SOURCE PREFIX-LENGTH is zero), Authoritative servers
-must omit such records if they wish to serve subnet-specific addresses.
-Such Authoritative servers can avoid the added latency of a followup query
-by setting TargetName to the value recommended in {{zone-performance}}.
+resolvers SHOULD treat any records in the Additional section as having
+SCOPE PREFIX-LENGTH zero, and MAY cache them on this basis.  Authoritative
+servers MUST omit such records if they are not suitable for global use.
+This will cause the resolver to perform a followup query that can receive
+properly tailored ECS.  (This is similar to the usage of CNAME with ECS
+discussed in {{!RFC7871}} Section 7.2.1.)
+
+Authoritative servers that omit Additional records can avoid the added
+latency of a followup query by following the advice in {{zone-performance}}.
 
 # Performance optimizations {#optimizations}
 

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -605,7 +605,7 @@ that are in the zone.  If the zone is signed, the server SHOULD also
 include positive or negative DNSSEC responses for these records in the Additional
 section.
 
-See {{ecs}} for exception.
+See {{ecs}} for exceptions.
 
 ## Recursive resolvers {#recursive-behavior}
 

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -679,6 +679,7 @@ SHOULD include the same ECS option in SVCB queries as in A/AAAA queries.
 
 According to Section 7.3.1 of {{!RFC7871}}, "Any records from \[the
 Additional section\] MUST NOT be tied to a network".  Accordingly,
+when processing a response whose QTYPE is SVCB-compatible,
 resolvers SHOULD treat any records in the Additional section as having
 SOURCE PREFIX-LENGTH zero and SCOPE PREFIX-LENGTH as specified
 in the ECS option.  Authoritative servers MUST omit such records if they are

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -674,11 +674,11 @@ section of a SVCB response when TargetName is in-zone, as recommended in
 
 SVCB records SHOULD NOT otherwise vary based on ECS.
 
-A recursive resolver that always returns A/AAAA records for TargetName in the
-Additional section, as recommended in {{recursive-behavior}}, SHOULD include
-an ECS option with a SOURCE PREFIX-LENGTH of zero in SVCB queries, to
-indicate that ECS is supported but is disabled for this query.  If the
-resolver might not return these Additional records, it SHOULD send the
+If the resolver plans to resolve A/AAAA records for TargetName and return
+them in the Additional section, as recommended in {{recursive-behavior}},
+it SHOULD include an ECS option with a SOURCE PREFIX-LENGTH of zero in SVCB
+queries, to indicate that ECS is supported but is disabled for this query.
+If the resolver does not plan to perform this resolution, it SHOULD send the
 same ECS option that it would use for an A/AAAA query.
 
 According to Section 7.3.1 of {{!RFC7871}}, "Any records from \[the


### PR DESCRIPTION
This change explains how to make SVCB play nicely with ECS, for both
recursive and authoritative servers.  The proposed behavior is
conservative, staying fully compliant with RFC 7871 (ECS) while allowing
improved caching performance when it is safe to do so.