### PR TITLE
Relax requirements for resolvers and SvcParams

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -649,10 +649,11 @@ See {{incomplete-response}} for possible optimizations of this procedure.
 
 ## General requirements
 
-Recursive resolvers MAY treat the SvcParams portion of the SVCB RR
-as opaque.  No part of this specification requires recursive resolvers
-to alter their behavior based on its contents, even if the contents are
-invalid.
+Recursive resolvers MUST be able to convey SVCB records with unrecognized
+SvcParamKeys or malformed SvcParamValues.  Resolvers MAY treat the entire
+SvcParams portion of the record as opaque.  No part of this specification requires
+recursive resolvers to alter their behavior based on its contents, even if the contents
+are invalid.
 
 When responding to a query that includes the DNSSEC OK bit ({{!RFC3225}}),
 DNSSEC-capable recursive and authoritative DNS servers MUST accompany

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -649,9 +649,10 @@ See {{incomplete-response}} for possible optimizations of this procedure.
 
 ## General requirements
 
-Recursive resolvers SHOULD treat the SvcParams portion of the SVCB RR
-as opaque and SHOULD NOT try to alter their behavior based
-on its contents.
+Recursive resolvers MAY treat the SvcParams portion of the SVCB RR
+as opaque.  No part of this specification requires recursive resolvers
+to alter their behavior based on its contents, even if the contents are
+invalid.
 
 When responding to a query that includes the DNSSEC OK bit ({{!RFC3225}}),
 DNSSEC-capable recursive and authoritative DNS servers MUST accompany


### PR DESCRIPTION
It's probably better for everyone if resolvers don't inspect the
SvcParams, but it's not really a requirement, and it has been a
controversial point due to implementation details and RDATA-based
filtering.