### PR TITLE
Adjust requirements for invalid SvcParamValues

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -655,9 +655,10 @@ Recursive resolvers MUST be able to convey SVCB records with unrecognized
 SvcParamKeys, and MAY treat the entire
 SvcParams portion of the record as opaque.  No part of this specification requires
 recursive resolvers to alter their behavior based on its contents, even if the contents
-are invalid.  To ensure compatibility with complex SvcParam specifications,
-recursive resolvers MAY validate the values of recognized SvcParamKeys, but
-MUST NOT reject the record on this basis unless a value is obviously invalid.
+are invalid.  Recursive resolvers MAY validate the values of recognized
+SvcParamKeys and reject records containing invalid values.  However, for
+complex value types whose interpretation might differ between implementations
+(e.g. URIs), resolvers SHOULD limit validation to basic sanity checks.
 
 When responding to a query that includes the DNSSEC OK bit ({{!RFC3225}}),
 DNSSEC-capable recursive and authoritative DNS servers MUST accompany

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -657,7 +657,7 @@ SvcParams portion of the record as opaque.  No part of this specification requir
 recursive resolvers to alter their behavior based on its contents, even if the contents
 are invalid.  Recursive resolvers MAY validate the values of recognized
 SvcParamKeys and reject records containing values 
-which are invalid according to the SvsParam specification.
+which are invalid according to the SvcParam specification.
 For complex value types whose interpretation might differ 
 between implementations or have additional future
 allowed values added (e.g. URIs or "alpn"), resolvers 

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -656,9 +656,12 @@ SvcParamKeys, and MAY treat the entire
 SvcParams portion of the record as opaque.  No part of this specification requires
 recursive resolvers to alter their behavior based on its contents, even if the contents
 are invalid.  Recursive resolvers MAY validate the values of recognized
-SvcParamKeys and reject records containing invalid values.  However, for
-complex value types whose interpretation might differ between implementations
-(e.g. URIs), resolvers SHOULD limit validation to basic sanity checks.
+SvcParamKeys and reject records containing values 
+which are invalid according to the SvsParam specification.
+For complex value types whose interpretation might differ 
+between implementations or have additional future
+allowed values added (e.g. URIs or "alpn"), resolvers 
+SHOULD limit validation to specified constraints.
 
 When responding to a query that includes the DNSSEC OK bit ({{!RFC3225}}),
 DNSSEC-capable recursive and authoritative DNS servers MUST accompany

--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -652,10 +652,12 @@ See {{incomplete-response}} for possible optimizations of this procedure.
 ## General requirements
 
 Recursive resolvers MUST be able to convey SVCB records with unrecognized
-SvcParamKeys or malformed SvcParamValues.  Resolvers MAY treat the entire
+SvcParamKeys, and MAY treat the entire
 SvcParams portion of the record as opaque.  No part of this specification requires
 recursive resolvers to alter their behavior based on its contents, even if the contents
-are invalid.
+are invalid.  To ensure compatibility with complex SvcParam specifications,
+recursive resolvers MAY validate the values of recognized SvcParamKeys, but
+MUST NOT reject the record on this basis unless a value is obviously invalid.
 
 When responding to a query that includes the DNSSEC OK bit ({{!RFC3225}}),
 DNSSEC-capable recursive and authoritative DNS servers MUST accompany


### PR DESCRIPTION
This change relaxes the requirement not to validate SvcParamValues, while encouraging resolvers to distinguish lightweight validation from deep parsing of complex value types.