### PR TITLE
Use the correct prefix for v4 mapped v6

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -1849,25 +1849,25 @@ Here, two IPv6 hints are quoted in the presentation format.
          \x00\x00\x00\x00\x00\x53\x00\x01              # second address
 
 
-This example shows a single IPv6 hint in IPv4 mapped IPv6 presentation
-format.
+This example shows a single IPv6 hint in IPv4-mapped IPv6 presentation
+format({{?RFC3513}}).
 
-    1 example.com. ipv6hint="2001:db8:ffff:ffff:ffff:ffff:198.51.100.100"
+    1 example.com. ipv6hint="::ffff:198.51.100.100"
 
     \# 35 (
     00 01                                              ; priority
     07 65 78 61 6d 70 6c 65 03 63 6f 6d 00             ; target
     00 06                                              ; key 6
     00 10                                              ; length 16
-    20 01 0d b8 ff ff ff ff ff ff ff ff c6 33 64 64    ; address
+    00 00 00 00 00 00 00 00 00 00 ff ff c6 33 64 64    ; address
     )
 
     \x00\x01                                           # priority
     \x07example\x03com\x00                             # target
     \x00\x06                                           # key 6
     \x00\x10                                           # length 16
-    \x20\x01\x0d\xb8\xff\xff\xff\xff
-         \xff\xff\xff\xff\xc6\x33\x64\x64              # address
+    \x00\x00\x00\x00\x00\x00\x00\x00
+         \x00\x00\xff\xff\xc6\x33\x64\x64              # address
 
 In the next vector, neither the SvcParamValues nor the mandatory keys are 
 sorted in presentation format, but are correctly sorted in the wire-format.


### PR DESCRIPTION
RFC 3513 section 2.5.5 tells us IPv4-mapped IPv6 lives in the ::ffff
prefix.