### PR TITLE
Correct ALPN comparison

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -1056,9 +1056,10 @@ differences in the intended client and server behavior.
 
 ### ALPN usage
 
-Unlike Alt-Svc Field Values, HTTPS RRs can contain multiple ALPN
-IDs, and clients are encouraged to offer additional ALPNs that they
-support.
+Unlike Alt-Svc Field Values, HTTPS RRs can contain multiple ALPN IDs.  Clients
+might choose to remove less-preferred ALPN IDs they offer when using HTTPS RRs,
+but they are not required to abort a connection attempt if a chosen ALPN ID is
+not negotiated by the server.
 
 ### Untrusted channel
 


### PR DESCRIPTION
This is the more verbose of the two options I considered.  It includes
more contextual information about what a client might choose to do with
HTTPS RRs.

In Alt-Svc, clients are required to consider an alternative "failed"
when the chosen ALPN is not negotiated by a server.  (This is something
I think we should remove, but I'll take that up in the revision.)  This
is a point of comparison with HTTPS RRs that is worth highlighting.

This could just say:

> Clients are not required to abort a connection attempt if a chosen
ALPN ID is not negotiated by the server.

The problem with that is that it doesn't really provide any information
on why that might be a problem.  Other text on the draft only really
talks about what to offer (which is absoltely the right thing to do).
That leaves readers with no context for the recommendation other than
text in RFC 7838.  This contextualizes it some.  It is perfectly
reasonable for clients to only use HTTPS RRs for what they perceive to
be protocol upgrades, using fallback behaviour for old protocols like
HTTP/1.1.

Closes #343.