### PR TITLE
Adjust H3 ref

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -128,8 +128,8 @@ additional DNS RR in a way that:
 
 Additional goals specific to HTTPS RRs and the HTTPS use-case include:
 
-* Connect directly to HTTP3 (QUIC transport)
-  alternative endpoints {{!HTTP3=I-D.ietf-quic-http}}
+* Connect directly to HTTP/3 (QUIC transport)
+  alternative endpoints {{?HTTP3=I-D.ietf-quic-http}}
 * Obtain the Encrypted ClientHello {{!ECH}} keys associated with an
   alternative endpoint
 * Support non-default TCP and UDP ports


### PR DESCRIPTION
I don't think we have a normative dependency on any of the HTTP mappings.  We might ought to have one on HTTP itself, but I'm raising that in my review on #341.