### PR TITLE
Offer a suggestion about multi-port aliasing

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -1291,7 +1291,9 @@ constraint when using aliases, including CNAME and AliasMode records.
 When using the generic SVCB RR type with aliasing, zone owners SHOULD choose alias
 target names that indicate the scheme in use (e.g. `foosvc.example.net` for
 `foo://` schemes).  This will help to avoid confusion when another scheme needs to
-be added to the configuration.
+be added to the configuration.  When multiple port numbers are in use, it may be
+helpful to repeat the prefix labels in the alias target name (e.g.
+`_1234._foo.svc.example.net`).
 
 ## Structuring zones for performance {#zone-performance}
 


### PR DESCRIPTION
Requested by @kaduk:

> The first is a bit hard for me to describe, but basically, when we
> construct a QNAME for an SVCB or HTTPS query, we include information
> reflecting URI scheme and port, but when we get a TargetName back, that's
> been flattened to a single name, in some sense "using up more" of the DNS
> hostname namespace under the control of the alternative endpoint then in
> the authority's namespace.  That is, if I wanted to provide service for
> both "foo" and "bar" schemes on two ports each, in order to serve all
> four combinations for a single service name, I would need to allocate four
> hostnames for alternative endpoints.  We do mention this property as it
> relates to URI schemes, in §11.1 where we say that "zone owners SHOULD
> choose alias target names that indicate the scheme in use", but I didn't
> see much discussion of the port-related aspects.  I know that the
> ServiceMode response can include a port to use in the parameters, so it's
> not really a concern about losing flexibility of what ports to use.  It
> just seems "unbalanced" in some sense that I can't really put my finger
> on.  On the other hand, it's not like hostnames are a particularly limited
> resource, so I don't really see any practical consequences of this setup;
> I'm just curious if this is a topic that the WG gave much consideration
> to.