### PR TITLE
Fix the char-string ABNF.

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -1745,7 +1745,9 @@ Here we summarize the allowed input to that algorithm, using ABNF:
                   "2" ( ( %x30-34 DIGIT ) / ( "5" %x30-35 ) )
     escaped     = "\" ( non-digit / dec-octet )
     contiguous  = 1*( non-special / escaped )
-    quoted      = DQUOTE *( contiguous / ( ["\"] WSP ) ) DQUOTE
+    ; VCHAR minus DQUOTE and "\"
+    quoted-char = WSP / "!" / %x23-5B / %x5D-7E
+    quoted      = DQUOTE *( quoted-char / escaped ) DQUOTE
     char-string = contiguous / quoted
 
 The decoding algorithm allows `char-string` to represent any `*OCTET`,


### PR DESCRIPTION
This PR changes the char-string ABNF to allow all printable characters other than double quote and backslash unescaped in the quoted variant of char-string.

Fixes #395.