### PR TITLE
Use fina $QNAME only when an AliasMode target

### DIFF
--- a/draft-ietf-dnsop-svcb-https.md
+++ b/draft-ietf-dnsop-svcb-https.md
@@ -535,6 +535,7 @@ be needed for connection establishment if the SVCB record is absent, in order to
 in that case and enable the optimizations discussed in {{optimizations}}.
 
 Once SVCB resolution has concluded, whether successful or not,
+if at least one AliasMode record was processed,
 SVCB-optional clients SHALL append to the priority list an
 endpoint consisting of the final value of $QNAME, the authority
 endpoint's port number, and no SvcParams.  (This endpoint will be


### PR DESCRIPTION
Per the title, use of $QNAME as an additional target was only ever intended when some positive number of AliasMode records were processed.